### PR TITLE
Use scope functionality for npm module dlls with a fallback to mapped mode.

### DIFF
--- a/lib/DelegatedModuleFactoryPlugin.js
+++ b/lib/DelegatedModuleFactoryPlugin.js
@@ -19,36 +19,46 @@ class DelegatedModuleFactoryPlugin {
 	}
 
 	apply(normalModuleFactory) {
-		const scope = this.options.scope;
+		const packageName = this.options.packageName;
+		const scopeOption = this.options.scope;
+		const scope = scopeOption || packageName;
 		if(scope) {
 			normalModuleFactory.plugin("factory", factory => (data, callback) => {
 				const dependency = data.dependencies[0];
 				const request = dependency.request;
 				if(request && request.indexOf(scope + "/") === 0) {
-					const innerRequest = "." + request.substr(scope.length);
-					let resolved;
-					if(innerRequest in this.options.content) {
-						resolved = this.options.content[innerRequest];
-						return callback(null, new DelegatedModule(this.options.source, resolved, this.options.type, innerRequest, request));
+					let possibleInnerRequests = [];
+					if(packageName) {
+						possibleInnerRequests.push(packageName + request.substr(scope.length));
 					}
-					for(let i = 0; i < this.options.extensions.length; i++) {
-						const extension = this.options.extensions[i];
-						const requestPlusExt = innerRequest + extension;
-						if(requestPlusExt in this.options.content) {
-							resolved = this.options.content[requestPlusExt];
-							return callback(null, new DelegatedModule(this.options.source, resolved, this.options.type, requestPlusExt, request + extension));
+					if(scopeOption) {
+						possibleInnerRequests.push("." + request.substr(scope.length));
+					}
+					let innerRequest = possibleInnerRequests.shift();
+					while(innerRequest) {
+						let resolved;
+						if(innerRequest in this.options.content) {
+							resolved = this.options.content[innerRequest];
+							return callback(null, new DelegatedModule(this.options.source, resolved, this.options.type, innerRequest, request));
 						}
+						for(let i = 0; i < this.options.extensions.length; i++) {
+							const extension = this.options.extensions[i];
+							const requestPlusExt = innerRequest + extension;
+							if(requestPlusExt in this.options.content) {
+								resolved = this.options.content[requestPlusExt];
+								return callback(null, new DelegatedModule(this.options.source, resolved, this.options.type, requestPlusExt, request + extension));
+							}
+						}
+						innerRequest = possibleInnerRequests.shift();
 					}
 				}
 				return factory(data, callback);
 			});
-		} else {
+		}
+		if(!scopeOption) {
 			normalModuleFactory.plugin("module", module => {
 				if(module.libIdent) {
 					let request = module.libIdent(this.options);
-					if(this.options.packageName && request.match(new RegExp(this.options.packageName))) {
-						request = `${this.options.packageName}${request.split(this.options.packageName)[1]}`;
-					}
 					if(request && request in this.options.content) {
 						const resolved = this.options.content[request];
 						return new DelegatedModule(this.options.source, resolved, this.options.type, request, module);


### PR DESCRIPTION
this will fix my issues with using typescript. It uses the scope logic for the given `packageName` but falls back to the default behavior if an external node_module path is given.
